### PR TITLE
change file diff and text preview to load monaco only on the client

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -5,6 +5,7 @@
 	"scripts": {
 		"dev": "vite dev",
 		"dev-bene": "VITE_PUBLIC_API=http://10.17.2.3:8080/api VITE_API=http://10.17.2.3:8080/api vite dev",
+		"dev-public": "VITE_PUBLIC_API=https://gum.benedikt-schwering.de/api VITE_API=https://gum.benedikt-schwering.de/api vite dev",
 		"build": "vite build",
 		"preview": "vite preview",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",

--- a/ui/src/routes/[repository]/diff/[fileVersionLeft]/[fileVersionRight]/+page.svelte
+++ b/ui/src/routes/[repository]/diff/[fileVersionLeft]/[fileVersionRight]/+page.svelte
@@ -1,5 +1,4 @@
 <script>
-    import {editor} from 'monaco-editor';
     import {onMount} from "svelte";
 
     export let data;
@@ -8,6 +7,8 @@
     let loading = true;
 
     onMount(async () => {
+        const {editor} = await import('monaco-editor');
+
         let diffEditor = editor.createDiffEditor(element, {
             theme: 'vs-dark',
             readOnly: true,

--- a/ui/src/routes/[repository]/file/[fileVersion]/TextPreview.svelte
+++ b/ui/src/routes/[repository]/file/[fileVersion]/TextPreview.svelte
@@ -1,5 +1,4 @@
 <script>
-    import {editor} from 'monaco-editor';
     import {onMount} from "svelte";
 
     export let data;
@@ -8,6 +7,8 @@
     let loading = true;
 
     onMount(async () => {
+        const {editor} = await import('monaco-editor');
+
         editor.create(element, {
             value: await (await fetch(`${data.publicApi}/${data.repository.id}/fileversion/${data.fileVersion.id}/preview`)).text(),
             theme: 'vs-dark',


### PR DESCRIPTION
When hitting F5 on file previews and diffs, a 500 error is thrown. Try it with this link: https://gum.benedikt-schwering.de/repo0/file/63d52457a0973b408d1a2b69

This may be caused by the monaco editor, which only works when window and document is present in the JavaScript context. When Svelte Kit tries to render it on the server, it runs into an error. Now its fixed to only load monaco on the client side.